### PR TITLE
#2 Hotfix - Removal of MongoDB for Express Server

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,29 +26,6 @@
         "concurrently": "^8.2.2"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "2.0.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
@@ -693,6 +670,7 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1129,6 +1107,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1170,6 +1149,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1267,6 +1247,7 @@
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,2 @@
 PORT=5000
-MONGO_URI=mongodb+srv://<username>:<password>@cluster.mongodb.net/<dbname>
 CLIENT_URL=http://localhost:5173

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
-import mongoose from 'mongoose';
 import exampleRoutes from './routes/example.routes.js';
 
 dotenv.config();
@@ -17,13 +16,4 @@ app.use('/api/examples', exampleRoutes);
 
 app.get('/api/health', (_req, res) => res.json({ status: 'ok' }));
 
-mongoose
-  .connect(process.env.MONGO_URI)
-  .then(() => {
-    console.log('MongoDB connected');
-    app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
-  })
-  .catch((err) => {
-    console.error('MongoDB connection error:', err);
-    process.exit(1);
-  });
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/models/example.model.js
+++ b/server/models/example.model.js
@@ -1,3 +1,6 @@
+// DEFUNCT CODE - no mongodb implementation
+// keeping for potential later use
+
 import mongoose from 'mongoose';
 
 const exampleSchema = new mongoose.Schema(


### PR DESCRIPTION
## Summary
This PR fixes the breaking bug of being unable to run the ExpressJS server via the `npm run dev` command. The server references to the `MONGO_URI` property of the `.env` file have been removed.

## Key Changes
- `server/.env.example` has been modified to remove the `MONGO_URI` field in its entirety.
- `server/index.js` has been refactored to remove the `MONGO_URI` dependency, and removed the `mongoose` import.
## Notes
- Because of the potential to use MongoDB in the future, the `mongoose` package has not been removed from the project.
- No test cases are required, as this pertains to the developer-side, not the product itself. As the project is currently a template, there is no lost functionality.

Closes #2. 