### PR TITLE
Implemented persistent filters for when users go from movie details p…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,7 +30,11 @@
     },
     "..": {
       "version": "1.0.0",
+      "dependencies": {
+        "dompurify": "^3.4.13"
+      },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "concurrently": "^8.2.2",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -90,7 +90,7 @@ function App() {
       <section id="search-page">
         <h1>Find a movie</h1>
         <SearchBar onQueryChange={setQuery} isLoading={isLoading} initialValue={query}/>
-        <FilterPanel onFiltersChange={setFilters} searchActive={query.length > 0} />
+        <FilterPanel onFiltersChange={setFilters} searchActive={query.length > 0} initialFilters={filters} />
         <SearchResultsList
           movies={movies}
           isLoading={isLoading}

--- a/client/src/components/FilterPanel.spec.tsx
+++ b/client/src/components/FilterPanel.spec.tsx
@@ -64,4 +64,16 @@ describe("FilterPanel", () => {
 
     expect(screen.queryByRole("button", { name: /action/i })).not.toBeInTheDocument();
   });
+
+  it("initializes controls from initialFilters", () => {
+    render(
+      <FilterPanel onFiltersChange={vi.fn()} initialFilters={{ genre: 27, ratingMin: 5, sort: "rating"}}/>,
+    );
+
+    expect(screen.getByLabelText(/genre/i)).toHaveValue("27");
+    expect(screen.getByLabelText(/minimum rating/i)).toHaveValue("5");
+    expect(screen.getByLabelText(/sort by/i)).toHaveValue("rating");
+  });
+
+  
 });

--- a/client/src/components/FilterPanel.tsx
+++ b/client/src/components/FilterPanel.tsx
@@ -19,21 +19,31 @@ const SORT_OPTIONS: {
 interface FilterPanelProps {
   onFiltersChange: (filters: DiscoverFilters) => void;
   searchActive?: boolean;
+  initialFilters?: DiscoverFilters;
 }
 
 export default function FilterPanel({
   onFiltersChange,
   searchActive = false,
+  initialFilters,
 }: Readonly<FilterPanelProps>) {
-  const [genreId, setGenreId] = useState<number | undefined>(undefined);
-  const [yearFrom, setYearFrom] = useState<number>(MIN_YEAR);
-  const [yearTo, setYearTo] = useState<number>(CURRENT_YEAR);
-  const [ratingMin, setRatingMin] = useState<number>(0);
-  const [sort, setSort] = useState<DiscoverFilters["sort"]>("popularity");
+  const [genreId, setGenreId] = useState<number | undefined>(initialFilters?.genre);
+  const [yearFrom, setYearFrom] = useState<number>(initialFilters?.yearFrom ?? MIN_YEAR);
+  const [yearTo, setYearTo] = useState<number>(initialFilters?.yearTo ?? CURRENT_YEAR);
+  const [ratingMin, setRatingMin] = useState<number>(initialFilters?.ratingMin ?? 0);
+  const [sort, setSort] = useState<DiscoverFilters["sort"]>(initialFilters?.sort ?? "popularity");
 
-  const [actorQuery, setActorQuery] = useState("");
+  const [actorQuery, setActorQuery] = useState(()=> {if (!initialFilters?.castId) return "";
+    const saved = sessionStorage.getItem("movieSearchActorName");
+    return saved ?? "";
+  });
   const [actorResults, setActorResults] = useState<Person[]>([]);
-  const [selectedActor, setSelectedActor] = useState<Person | null>(null);
+  const [selectedActor, setSelectedActor] = useState<Person | null>(() => {
+    if (!initialFilters?.castId) return null;
+    const savedName = sessionStorage.getItem("movieSearchActorName");
+    if (!savedName) return null;
+    return { id: initialFilters.castId, name: savedName } as Person;
+  });
   const [actorSearchLoading, setActorSearchLoading] = useState(false);
 
   useEffect(() => {
@@ -77,12 +87,14 @@ export default function FilterPanel({
     setSelectedActor(person);
     setActorQuery(person.name);
     setActorResults([]);
+    sessionStorage.setItem("movieSearchActorName", person.name);
   }
 
   function clearActor() {
     setSelectedActor(null);
     setActorQuery("");
     setActorResults([]);
+    sessionStorage.removeItem("movieSearchActorName");
   }
 
   function clearAll() {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,7 +22,11 @@
     },
     "..": {
       "version": "1.0.0",
+      "dependencies": {
+        "dompurify": "^3.4.13"
+      },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "concurrently": "^8.2.2",


### PR DESCRIPTION
<!-- Please do not delete any of the header fields - leave blank if necessary. -->

<!-- Please format the title roughly as such: 
[Overview of PR] ([Issue number])
e.g. "Hotfix of npm crash (#21)"
--> Persistent filters (#47)

## Mandatory Checklist
<!-- All points should be met before submitting a Pull Request. This checklist is denoted as tasks in Github. -->
<!-- To denote a completed checkbox, replace "[ ]" with "[x]". -->

- [x] The latest commit of my PR runs without crashing
- [x] All existing test cases pass
- [x] There is an existing issue that corresponds to this PR
- [x] This PR branch has been rebased onto the `main` of the original repository
- [x] All code changes have been checked through SonarLint, as per assignment specifications

- [x] \(Optional) If any code has been added, there are tests to assert these changes 
- [x] \(Optional) The documentation has been changed to reflect changed code, if any

## Issue Addressed
<!-- Please use closing keywords and reference the issue number, e.g. "Closes #12." --> Closes #47 

## Summary Description
<!-- What does this PR address? Describe in broad details how this has been done. --> Pull request addresses issue where upon users selecting a filter when searching a movie, and then enters a movie details page, the details of the filters are lost upon returning back to the search page. This PR makes sure that upon user returning back to search page the filters are retained.

## Key Changes
<!-- A list of the major changes made for the PR, in one or few sentences. -->
- Added initialFilters prop to FilterPanel so filter values are initialized from saved state instead of resetting to defaults
- Added test to check it works correctly

## Notes (Optional)
<!-- Is there any details we need to know about the implementation, or other factors relating to the PR? -->
N/A <!-- Replace as required -->