### PR TITLE
Adjusting Cluster Node Backend (#57)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -97,7 +97,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -111,7 +110,6 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -215,6 +213,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -259,6 +258,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1602,8 +1602,7 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1628,6 +1627,7 @@
       "version": "26.2.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1636,6 +1636,7 @@
       "version": "19.2.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1644,6 +1645,7 @@
       "version": "19.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2143,7 +2145,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2255,6 +2256,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -2529,6 +2531,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2636,8 +2639,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.407",
@@ -2920,6 +2922,7 @@
       "version": "29.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3242,7 +3245,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3272,6 +3274,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -3445,6 +3448,7 @@
     "node_modules/picomatch": {
       "version": "4.0.5",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3469,6 +3473,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -3507,7 +3512,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3545,6 +3549,7 @@
     "node_modules/react": {
       "version": "19.2.8",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3552,6 +3557,7 @@
     "node_modules/react-dom": {
       "version": "19.2.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3579,8 +3585,7 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-kapsule": {
       "version": "2.6.0",
@@ -3931,6 +3936,7 @@
       "version": "7.0.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc"
       },
@@ -4015,6 +4021,7 @@
     "node_modules/vite": {
       "version": "8.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -4091,6 +4098,7 @@
       "version": "4.1.10",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/client/src/components/MovieGraph.test.tsx
+++ b/client/src/components/MovieGraph.test.tsx
@@ -9,134 +9,241 @@ import type { MovieGraphData, MovieGraphNode } from "./movieGraphData";
 
 // The real graph draws to a canvas, which jsdom has no renderer for. Standing in
 // for it with buttons keeps the data and the click handling under test.
+// vi.mock("react-force-graph-2d", () => ({
+//   default: ({
+//     graphData,
+//     onNodeClick,
+//   }: Readonly<{
+//     graphData: MovieGraphData;
+//     onNodeClick: (node: MovieGraphNode) => void;
+//   }>) => (
+//     <div data-testid="graph">
+//       {graphData.nodes.map((node) => (
+//         <button key={node.id} type="button" onClick={() => onNodeClick(node)}>
+//           {node.title}
+//         </button>
+//       ))}
+//     </div>
+//   ),
+// }));
+
 vi.mock("react-force-graph-2d", () => ({
-  default: ({
+default: ({
     graphData,
     onNodeClick,
-  }: Readonly<{
+    nodeCanvasObject,
+}: Readonly<{
     graphData: MovieGraphData;
     onNodeClick: (node: MovieGraphNode) => void;
-  }>) => (
+    nodeCanvasObject?: (node: MovieGraphNode, ctx: CanvasRenderingContext2D, globalScale: number) => void;
+}>) => (
     <div data-testid="graph">
-      {graphData.nodes.map((node) => (
-        <button key={node.id} type="button" onClick={() => onNodeClick(node)}>
-          {node.title}
-        </button>
-      ))}
+    {graphData.nodes.map((node) => {
+        let fillColor = "";
+
+        
+        const fakeCtx = {
+            // spied fields used in constructor - required
+            beginPath: vi.fn(),
+            arc: vi.fn(),
+            fill: vi.fn(),
+            stroke: vi.fn(),
+            fillText: vi.fn(),
+            font: "",
+            textAlign: "",
+            textBaseline: "",
+
+            // fill hook when rendered, capture value
+            set fillStyle(val: string) {
+                if (!fillColor) {
+                fillColor = val;
+                }
+            },
+        } as unknown as CanvasRenderingContext2D; // force mock as canvas context
+
+        // write node into the mocked canvas
+        if (nodeCanvasObject) {
+            nodeCanvasObject(node, fakeCtx, 1);
+        }
+
+        // check node color (indicating level 0/1/2), true = level 0/1
+        const isExpanded = fillColor !== "#5c5866";
+    
+        // returns button per node to mock as clickable on canvas
+        return (
+            <button
+                key={node.id}
+                type="button"
+                data-node-id={node.id}
+                aria-expanded={isExpanded} // read to check expansion state in tests
+                onClick={() => onNodeClick(node)}
+            >
+                {node.title}
+            </button>
+        );
+    })}
     </div>
-  ),
+),
 }));
 
-function rawMovie(id: number, title: string) {
-  return {
-    id,
-    title,
-    release_date: "2001-01-01",
-    poster_path: null,
-    overview: null,
-    genre_ids: null,
-    vote_average: null,
-  };
+    function rawMovie(id: number, title: string) {
+    return {
+        id,
+        title,
+        release_date: "2001-01-01",
+        poster_path: null,
+        overview: null,
+        genre_ids: null,
+        vote_average: null,
+    };
+    }
+
+    /** Recommendations that differ per movie, so expanding a node adds something new. */
+function useBranchingRecommendations() {
+    server.use(
+        http.get("https://api.themoviedb.org/3/movie/:id/recommendations", ({ params }) => {
+        const results =
+            Number(params.id) === 1
+            ? [rawMovie(100, "First Neighbour")]
+            : [rawMovie(200, "Second Neighbour")];
+
+        return HttpResponse.json({
+            results,
+            page: 1,
+            total_pages: 1,
+            total_results: results.length,
+        });
+        }),
+    );
 }
 
-/** Recommendations that differ per movie, so expanding a node adds something new. */
-function useBranchingRecommendations() {
-  server.use(
-    http.get("https://api.themoviedb.org/3/movie/:id/recommendations", ({ params }) => {
-      const results =
-        Number(params.id) === 1
-          ? [rawMovie(100, "First Neighbour")]
-          : [rawMovie(200, "Second Neighbour")];
+function useMultiLevelRecommendations() {
+    server.use(
+        http.get("https://api.themoviedb.org/3/movie/:id/recommendations", ({ params }) => {
+        const id = Number(params.id);
+        // something like root below, except movie A links back to root (https://diagon.arthursonzogni.com/)
+        // ┌────────────┐      
+        // │root        │      
+        // └┬──────────┬┘      
+        // ┌▽────────┐┌▽───────┐
+        // │movie B  │ │movie A │
+        // └┬───────┬┘ └┬───────┘
+        // ┌▽─────┐┌▽──▽──┐    
+        // │unique│ │shared│    
+        // └──────┘ └──────┘    
 
-      return HttpResponse.json({
-        results,
-        page: 1,
-        total_pages: 1,
-        total_results: results.length,
-      });
-    }),
-  );
+        if (id === 1) {
+            // root returns level 1s A and B
+            return HttpResponse.json({
+            results: [rawMovie(2, "movie A"), rawMovie(3, "movie B")],
+            });
+        }
+        if (id === 2) {
+            // movie A links back to root and level 2 shared
+            return HttpResponse.json({
+            results: [rawMovie(4, "shared"), rawMovie(1, "Root Movie")],
+            });
+        }
+        if (id === 3) {
+            // movie B
+            return HttpResponse.json({
+            results: [rawMovie(4, "shared"), rawMovie(5, "unique")],
+            });
+        }
+        return HttpResponse.json({ results: [] });
+        }),
+    );
 }
 
 function LocationDisplay() {
-  const location = useLocation();
-  return <span data-testid="location">{location.pathname}</span>;
+    const location = useLocation();
+    return <span data-testid="location">{location.pathname}</span>;
 }
 
 function renderGraph() {
-  return render(
-    <MemoryRouter>
-      <MovieGraph movieId={1} title="Root Movie" year={1999} />
-      <LocationDisplay />
-    </MemoryRouter>,
-  );
+    return render(
+        <MemoryRouter>
+            <MovieGraph movieId={1} title="Root Movie" year={1999} />
+            <LocationDisplay />
+        </MemoryRouter>,
+    );
 }
 
 describe("MovieGraph", () => {
-  beforeAll(() => {
-    // jsdom reports every element as zero-width; the canvas needs a real width.
-    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
-      configurable: true,
-      value: 800,
+    beforeAll(() => {
+        // jsdom reports every element as zero-width; the canvas needs a real width.
+        Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        value: 800,
+        });
     });
-  });
 
-  it("shows the movie itself while its connections load", () => {
-    renderGraph();
+    it("shows the movie itself while its connections load", () => {
+        renderGraph();
 
-    expect(screen.getByRole("button", { name: "Root Movie" })).toBeInTheDocument();
-    expect(screen.getByText(/Loading related movies/i)).toBeInTheDocument();
-  });
+        expect(screen.getByRole("button", { name: "Root Movie" })).toBeInTheDocument();
+        expect(screen.getByText(/Loading related movies/i)).toBeInTheDocument();
+    });
 
-  it("adds the related movies once they load", async () => {
-    useBranchingRecommendations();
-    renderGraph();
+    it("adds the related movies once they load", async () => {
+        useBranchingRecommendations();
+        renderGraph();
 
-    expect(await screen.findByRole("button", { name: "First Neighbour" })).toBeInTheDocument();
-    expect(screen.getByText("2 movies, 1 connection")).toBeInTheDocument();
-  });
+        expect(await screen.findByRole("button", { name: "First Neighbour" })).toBeInTheDocument();
+        expect(screen.getByText("3 movies, 2 connections")).toBeInTheDocument();
+    });
 
-  it("branches out from a movie when it is clicked", async () => {
-    useBranchingRecommendations();
-    renderGraph();
+    it("does not duplicate nodes when referenced twice", async () => {
+        useMultiLevelRecommendations();
+        renderGraph();
 
-    await userEvent.click(await screen.findByRole("button", { name: "First Neighbour" }));
+        // Wait for the complete 2-level graph to finish rendering
+        await screen.findByRole("button", { name: "unique" });
 
-    expect(await screen.findByRole("button", { name: "Second Neighbour" })).toBeInTheDocument();
-    expect(screen.getByText("3 movies, 2 connections")).toBeInTheDocument();
-  });
+        const allButtons = screen.getAllByRole("button");
+        const nodeIds = allButtons.map((btn) => btn.getAttribute("data-node-id"));
 
-  it("opens the movie page when an already-branched movie is clicked again", async () => {
-    useBranchingRecommendations();
-    renderGraph();
+        // Verify exactly 5 unique nodes were created (Root, 2x L1, 2x L2)
+        expect(allButtons).toHaveLength(5);
+        expect(new Set(nodeIds).size).toBe(5);
+    });
 
-    const neighbour = await screen.findByRole("button", { name: "First Neighbour" });
-    await userEvent.click(neighbour);
-    await screen.findByRole("button", { name: "Second Neighbour" });
+    it("does not mark level 2 recommendation nodes as expanded on initial load", async () => {
+        useMultiLevelRecommendations();
+        renderGraph();
 
-    await userEvent.click(screen.getByRole("button", { name: "First Neighbour" }));
+        await screen.findByRole("button", { name: "unique" });
 
-    expect(screen.getByTestId("location")).toHaveTextContent("/movie/100");
-  });
+        // Root and Level 1 nodes should be marked expanded
+        expect(screen.getByRole("button", { name: "Root Movie" })).toHaveAttribute("aria-expanded", "true");
+        expect(screen.getByRole("button", { name: "movie A" })).toHaveAttribute("aria-expanded", "true");
+        expect(screen.getByRole("button", { name: "movie B" })).toHaveAttribute("aria-expanded", "true");
 
-  it("stays put when the movie at the centre is clicked", async () => {
-    useBranchingRecommendations();
-    renderGraph();
+        // Level 2 nodes must NOT be marked expanded
+        expect(screen.getByRole("button", { name: "shared" })).toHaveAttribute("aria-expanded", "false");
+        expect(screen.getByRole("button", { name: "unique" })).toHaveAttribute("aria-expanded", "false");
+    });
 
-    await screen.findByRole("button", { name: "First Neighbour" });
-    await userEvent.click(screen.getByRole("button", { name: "Root Movie" }));
+    it("stays put when the movie at the centre is clicked", async () => {
+        useBranchingRecommendations();
+        renderGraph();
 
-    expect(screen.getByTestId("location").textContent).toBe("/");
-  });
+        // wait until all neighbors load (2nd is last)
+        await screen.findByRole("button", { name: "Second Neighbour" });
 
-  it("reports a failure to load related movies", async () => {
-    server.use(
-      http.get("https://api.themoviedb.org/3/movie/:id/recommendations", () =>
-        HttpResponse.json({ status_message: "nope" }, { status: 500 }),
-      ),
-    );
-    renderGraph();
+        await userEvent.click(screen.getByRole("button", { name: "Root Movie" }));
 
-    expect(await screen.findByText(/Could not load related movies/i)).toBeInTheDocument();
-  });
+        expect(screen.getByTestId("location").textContent).toBe("/");
+    });
+
+    it("reports a failure to load related movies", async () => {
+        server.use(
+        http.get("https://api.themoviedb.org/3/movie/:id/recommendations", () =>
+            HttpResponse.json({ status_message: "nope" }, { status: 500 }),
+        ),
+        );
+        renderGraph();
+
+        expect(await screen.findByText(/Could not load related movies/i)).toBeInTheDocument();
+    });
 });

--- a/client/src/components/MovieGraph.test.tsx
+++ b/client/src/components/MovieGraph.test.tsx
@@ -7,26 +7,7 @@ import { server } from "../test/server";
 import MovieGraph from "./MovieGraph";
 import type { MovieGraphData, MovieGraphNode } from "./movieGraphData";
 
-// The real graph draws to a canvas, which jsdom has no renderer for. Standing in
-// for it with buttons keeps the data and the click handling under test.
-// vi.mock("react-force-graph-2d", () => ({
-//   default: ({
-//     graphData,
-//     onNodeClick,
-//   }: Readonly<{
-//     graphData: MovieGraphData;
-//     onNodeClick: (node: MovieGraphNode) => void;
-//   }>) => (
-//     <div data-testid="graph">
-//       {graphData.nodes.map((node) => (
-//         <button key={node.id} type="button" onClick={() => onNodeClick(node)}>
-//           {node.title}
-//         </button>
-//       ))}
-//     </div>
-//   ),
-// }));
-
+// mocks graph due to jsdom limitations for canvas rendering
 vi.mock("react-force-graph-2d", () => ({
 default: ({
     graphData,

--- a/client/src/components/MovieGraph.tsx
+++ b/client/src/components/MovieGraph.tsx
@@ -12,8 +12,8 @@ import {
 } from "./movieGraphData";
 import "./MovieGraph.css";
 
-const GRAPH_HEIGHT = 420;
-const MAX_RELATED_PER_MOVIE = 8;
+const GRAPH_HEIGHT = 600;
+const MAX_RELATED_PER_MOVIE = 10;
 const MAX_LABEL_LENGTH = 24;
 
 const BACKGROUND_COLOR = "#16151a";
@@ -79,32 +79,48 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
     return () => observer.disconnect();
   }, []);
 
-  // Start over whenever the page moves to a different movie.
-  useEffect(() => {
-    const controller = new AbortController();
+    // Start over whenever the page moves to a different movie.
+    useEffect(() => {
+        const controller = new AbortController();
 
-    setGraph(createGraph({ id: movieId, title, year }));
-    setExpandedIds(new Set());
-    setError(null);
-    setLoadingId(movieId);
-    shouldRefitRef.current = true;
-
-    fetchRecommendedMovies(movieId, controller.signal)
-      .then((related) => {
-        setGraph((current) =>
-          addRelatedMovies(current, movieId, related, MAX_RELATED_PER_MOVIE),
-        );
-        setExpandedIds(new Set([movieId]));
-        setLoadingId(null);
+        setGraph(createGraph({ id: movieId, title, year }));
+        setExpandedIds(new Set());
+        setError(null);
+        setLoadingId(movieId);
         shouldRefitRef.current = true;
-      })
-      .catch((err: Error) => {
-        if (err.name === "AbortError") {
-          return;
-        }
-        setError("Could not load related movies.");
-        setLoadingId(null);
-      });
+
+        fetchRecommendedMovies(movieId, controller.signal)
+            .then(async (relatedMovies) => {
+                let updatedGraph = addRelatedMovies(createGraph({ id: movieId, title, year }), movieId, relatedMovies, MAX_RELATED_PER_MOVIE);
+                const expanded = new Set([movieId]);
+
+                const moviePromise2 = relatedMovies.map((l1Movie) => {
+                    return fetchRecommendedMovies(l1Movie.id, controller.signal)
+                        .then((related) => ({id: l1Movie.id, related: related}))
+                        .catch(() => null) // do nothing when fetch fails - fine to ignore some
+                })
+
+
+                const relatedMovies2Results = await Promise.all(moviePromise2);
+
+                relatedMovies2Results.forEach((movie2) => {
+                    if (movie2) { // for all promises that didn't fail
+                        updatedGraph = addRelatedMovies(updatedGraph, movie2.id, movie2.related, MAX_RELATED_PER_MOVIE);
+                        expanded.add(movie2.id);
+                    }
+                })
+
+                setGraph(updatedGraph);
+                setExpandedIds(expanded);
+                setLoadingId(null);
+                shouldRefitRef.current = true;
+            }).catch((err: Error) => {
+                if (err.name === "AbortError") {
+                return;
+                }
+                setError("Could not load related movies.");
+                setLoadingId(null);
+            })
 
     return () => controller.abort();
   }, [movieId, title, year]);

--- a/client/src/components/MovieGraph.tsx
+++ b/client/src/components/MovieGraph.tsx
@@ -210,8 +210,7 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
   return (
     <div className="movie-graph">
       <p className="movie-graph__hint">
-        Click a movie to branch out from it, click it again to open its page. Drag the
-        movies around to untangle them, scroll to zoom.
+        Click a movie node to view its detail page. Scroll to zoom, and drag to pan. Nodes can be dragged around.
       </p>
 
       <div className="movie-graph__canvas" ref={containerRef} style={{ height: GRAPH_HEIGHT }}>
@@ -228,15 +227,19 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
             nodePointerAreaPaint={paintPointerArea}
             linkColor={() => LINK_COLOR}
             linkWidth={1}
-            onNodeClick={(node) => navigate(`/movie/${node.id}`)}
+            onNodeClick={(node) => {
+                if (Number(node.id) !== movieId) { // do nothing if clicked center node
+                    navigate(`/movie/${node.id}`)
+                }
+            }}
             onEngineStop={handleEngineStop}
           />
         )}
       </div>
-
-      <p className="movie-graph__status" aria-live="polite">
+      <p className="movie-graph__status" aria-live="polite"> 
         {status}
       </p>
     </div>
+    
   );
 }

--- a/client/src/components/MovieGraph.tsx
+++ b/client/src/components/MovieGraph.tsx
@@ -91,16 +91,19 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
 
         fetchRecommendedMovies(movieId, controller.signal)
             .then(async (relatedMovies) => {
-                let updatedGraph = addRelatedMovies(createGraph({ id: movieId, title, year }), movieId, relatedMovies, MAX_RELATED_PER_MOVIE);
+                // prevent processing unrendered recommendations (causes visual bug)
+                const relatedMoviesSliced = relatedMovies.slice(0, MAX_RELATED_PER_MOVIE);
+                let updatedGraph = addRelatedMovies(createGraph({ id: movieId, title, year }), movieId, relatedMoviesSliced, MAX_RELATED_PER_MOVIE);
                 const expanded = new Set([movieId]);
 
-                const moviePromise2 = relatedMovies.map((l1Movie) => {
+                // for each recommended movie, create a promise to get 2-deep recommended movies
+                const moviePromise2 = relatedMoviesSliced.map((l1Movie) => {
                     return fetchRecommendedMovies(l1Movie.id, controller.signal)
                         .then((related) => ({id: l1Movie.id, related: related}))
                         .catch(() => null) // do nothing when fetch fails - fine to ignore some
                 })
 
-
+                // resolve all promises parallel-wise (not sequential)
                 const relatedMovies2Results = await Promise.all(moviePromise2);
 
                 relatedMovies2Results.forEach((movie2) => {
@@ -110,10 +113,12 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
                     }
                 })
 
+                // update all relevant nodes
                 setGraph(updatedGraph);
                 setExpandedIds(expanded);
                 setLoadingId(null);
                 shouldRefitRef.current = true;
+
             }).catch((err: Error) => {
                 if (err.name === "AbortError") {
                 return;
@@ -124,41 +129,6 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
 
     return () => controller.abort();
   }, [movieId, title, year]);
-
-  const handleNodeClick = useCallback(
-    (node: MovieGraphNode) => {
-      // A movie that has already been branched out from has nothing left to
-      // reveal, so a second click opens it instead.
-      if (expandedIds.has(node.id)) {
-        if (node.id !== movieId) {
-          navigate(`/movie/${node.id}`);
-        }
-        return;
-      }
-
-      if (loadingId !== null) {
-        return;
-      }
-
-      setLoadingId(node.id);
-      setError(null);
-
-      fetchRecommendedMovies(node.id)
-        .then((related) => {
-          setGraph((current) =>
-            addRelatedMovies(current, node.id, related, MAX_RELATED_PER_MOVIE),
-          );
-          setExpandedIds((current) => new Set(current).add(node.id));
-          setLoadingId(null);
-          shouldRefitRef.current = true;
-        })
-        .catch(() => {
-          setError("Could not load related movies.");
-          setLoadingId(null);
-        });
-    },
-    [expandedIds, loadingId, movieId, navigate],
-  );
 
   const nodeColor = useCallback(
     (node: MovieGraphNode) => {
@@ -258,7 +228,7 @@ export default function MovieGraph({ movieId, title, year }: Readonly<Props>) {
             nodePointerAreaPaint={paintPointerArea}
             linkColor={() => LINK_COLOR}
             linkWidth={1}
-            onNodeClick={handleNodeClick}
+            onNodeClick={(node) => navigate(`/movie/${node.id}`)}
             onEngineStop={handleEngineStop}
           />
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }

--- a/server/controllers/movies.controller.js
+++ b/server/controllers/movies.controller.js
@@ -37,3 +37,7 @@ export const getRandomMovie = async (_req, res) => {
         res.status(500).json({ message: err.message })
     }
 }
+
+export const getLikeMovies = async(_req, res) => {
+    // return in 60/30/10 style, genre-releaseyear-director
+}

--- a/server/controllers/movies.controller.js
+++ b/server/controllers/movies.controller.js
@@ -37,7 +37,3 @@ export const getRandomMovie = async (_req, res) => {
         res.status(500).json({ message: err.message })
     }
 }
-
-export const getLikeMovies = async(_req, res) => {
-    // return in 60/30/10 style, genre-releaseyear-director
-}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2579,6 +2579,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2693,6 +2694,7 @@
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",


### PR DESCRIPTION
<!-- Please do not delete any of the header fields - leave blank if necessary. -->

<!-- Please format the title roughly as such: 
[Overview of PR] ([Issue number])
e.g. "Hotfix of npm crash (#21)"
-->

## Mandatory Checklist
<!-- All points should be met before submitting a Pull Request. This checklist is denoted as tasks in Github. -->
<!-- To denote a completed checkbox, replace "[ ]" with "[x]". -->

- [x] The latest commit of my PR runs without crashing
- [x] All existing test cases pass
- [x] There is an existing issue that corresponds to this PR
- [x] This PR branch has been rebased onto the `main` of the original repository
- [x] All code changes have been checked through SonarLint, as per assignment specifications
- [x] \(Optional) If any code has been added, there are tests to assert these changes 
- [x] \(Optional) The documentation has been changed to reflect changed code, if any

## Issue Addressed
<!-- Please use closing keywords and reference the issue number, e.g. "Closes #12." -->
Closes #57. 

## Summary Description
<!-- What does this PR address? Describe in broad details how this has been done. -->
This adjusts the initial implementation of the cluster node map, instead now initially rendering up to 2 levels of recommendations deep. The expand/collapse colors indicate level and should be intuitive to the user. Proximity is inherently enforced due to render order and branching style loading.

## Key Changes
<!-- A list of the major changes made for the PR, in one or few sentences. -->
- Test case added to ensure no node duplication
- Cluster node maps initially starts at 2 levels deep, single clicks navigate to movie details page

## Notes (Optional)
<!-- Is there any details we need to know about the implementation, or other factors relating to the PR? -->
With assistance of Gemini for understanding mock structure, and structuring test cases